### PR TITLE
copy(invite-card): "Present this at the gate"

### DIFF
--- a/components/invite-card.tsx
+++ b/components/invite-card.tsx
@@ -80,7 +80,7 @@ export const InviteCard = forwardRef<HTMLDivElement, InviteCardProps>(
             style={{ marginBottom: 20, lineHeight: 1.4 }}
             className="text-xs text-slate-500"
           >
-            Scan the QR code to claim your ticket
+            Present this at the gate
           </p>
 
           <p


### PR DESCRIPTION
The QR now goes straight to organizer check-in, not a claim flow, so the old "Scan the QR code to claim your ticket" wording was wrong.