### PR TITLE
feat(invites): category select on invites + show on QR card and scan

### DIFF
--- a/app/organizer/view-event/[id]/EventManagementTabs.tsx
+++ b/app/organizer/view-event/[id]/EventManagementTabs.tsx
@@ -53,6 +53,7 @@ import {
   useRemoveInvitee,
   useGenerateShareableLink,
   useRevokeShareableLink,
+  useUpdateInvite,
 } from "@/services/invites/invites.queries";
 import { useSendMessage } from "@/services/messages/messages.queries";
 
@@ -63,6 +64,7 @@ interface EventManagementTabsProps {
   eventName?: string;
   eventDate?: string | Date | null;
   eventLocation?: string | null;
+  ticketCategories?: Array<{ id: string; name: string }>;
 }
 
 export default function EventManagementTabs({
@@ -72,6 +74,7 @@ export default function EventManagementTabs({
   eventName,
   eventDate,
   eventLocation,
+  ticketCategories = [],
 }: EventManagementTabsProps) {
   const { toast } = useToast();
 
@@ -113,6 +116,7 @@ export default function EventManagementTabs({
 
   // ── Invites state ────────────────────────────────────────────
   const { data: invites, isLoading: invitesLoading } = useListInvites(eventId);
+  const { mutate: updateInvite } = useUpdateInvite(eventId);
   const { data: shareableLink, isLoading: linkLoading } =
     useShareableLink(eventId);
   const { mutate: addInvitee, isPending: addingInvitee } =
@@ -130,7 +134,14 @@ export default function EventManagementTabs({
     contactMethod: "email" | "phone";
     email: string;
     phone: string;
-  }>({ name: "", contactMethod: "email", email: "", phone: "" });
+    ticketCategoryId: string;
+  }>({
+    name: "",
+    contactMethod: "email",
+    email: "",
+    phone: "",
+    ticketCategoryId: "",
+  });
   const [copiedLink, setCopiedLink] = useState(false);
   const [qrInvite, setQrInvite] = useState<Invite | null>(null);
   const [qrBlobUrl, setQrBlobUrl] = useState<string | null>(null);
@@ -152,6 +163,9 @@ export default function EventManagementTabs({
       ...(inviteForm.contactMethod === "email"
         ? { email: inviteForm.email }
         : { phone: inviteForm.phone }),
+      ...(inviteForm.ticketCategoryId
+        ? { ticketCategoryId: inviteForm.ticketCategoryId }
+        : {}),
     };
     const label =
       inviteForm.contactMethod === "email"
@@ -164,6 +178,7 @@ export default function EventManagementTabs({
           contactMethod: inviteForm.contactMethod,
           email: "",
           phone: "",
+          ticketCategoryId: inviteForm.ticketCategoryId,
         });
         if (mode === "SEND") {
           toast({ title: "Invite sent", description: `Invite sent to ${label}.` });
@@ -184,6 +199,8 @@ export default function EventManagementTabs({
               status: "PENDING",
               token: added.inviteToken ?? "",
               inviteLink: added.inviteLink,
+              admitsCount: added.admitsCount,
+              ticketCategoryName: added.ticketCategoryName,
             });
           }
         }
@@ -546,6 +563,34 @@ export default function EventManagementTabs({
                     </div>
                   )}
 
+                  {ticketCategories.length > 0 && (
+                    <div className="space-y-1">
+                      <Label>Category (optional)</Label>
+                      <Select
+                        value={inviteForm.ticketCategoryId || "none"}
+                        onValueChange={(v) =>
+                          setInviteForm((f) => ({
+                            ...f,
+                            ticketCategoryId: v === "none" ? "" : v,
+                          }))
+                        }
+                        disabled={addingInvitee}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="No category" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="none">No category</SelectItem>
+                          {ticketCategories.map((c) => (
+                            <SelectItem key={c.id} value={c.id}>
+                              {c.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
                   <div className="flex flex-col sm:flex-row gap-2 pt-1">
                     <Button
                       type="button"
@@ -600,6 +645,11 @@ export default function EventManagementTabs({
                         <tr className="border-b text-muted-foreground">
                           <th className="text-left py-2 pr-4 font-medium">Name</th>
                           <th className="text-left py-2 pr-4 font-medium">Contact</th>
+                          {ticketCategories.length > 0 && (
+                            <th className="text-left py-2 pr-4 font-medium">
+                              Category
+                            </th>
+                          )}
                           <th className="text-left py-2 pr-4 font-medium">Status</th>
                           <th className="text-left py-2 font-medium">Actions</th>
                         </tr>
@@ -615,6 +665,51 @@ export default function EventManagementTabs({
                                 </span>
                               )}
                             </td>
+                            {ticketCategories.length > 0 && (
+                              <td className="py-2 pr-4">
+                                <Select
+                                  value={inv.ticketCategoryId || "none"}
+                                  onValueChange={(v) =>
+                                    updateInvite(
+                                      {
+                                        inviteId: inv.id,
+                                        payload: {
+                                          ticketCategoryId:
+                                            v === "none" ? null : v,
+                                        },
+                                      },
+                                      {
+                                        onSuccess: () =>
+                                          toast({
+                                            title: "Category updated",
+                                          }),
+                                        onError: () =>
+                                          toast({
+                                            title: "Error",
+                                            description:
+                                              "Failed to update category.",
+                                            variant: "destructive",
+                                          }),
+                                      },
+                                    )
+                                  }
+                                >
+                                  <SelectTrigger className="h-8 w-[140px]">
+                                    <SelectValue placeholder="No category" />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="none">
+                                      No category
+                                    </SelectItem>
+                                    {ticketCategories.map((c) => (
+                                      <SelectItem key={c.id} value={c.id}>
+                                        {c.name}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                </Select>
+                              </td>
+                            )}
                             <td className="py-2 pr-4">
                               <span
                                 className={`text-xs font-medium px-2 py-0.5 rounded-full ${
@@ -909,6 +1004,8 @@ export default function EventManagementTabs({
                 eventDate={eventDate}
                 eventLocation={eventLocation}
                 inviteeName={qrInvite?.name}
+                admitsCount={qrInvite?.admitsCount}
+                categoryName={qrInvite?.ticketCategoryName}
                 qrUrl={qrBlobUrl}
               />
             )}

--- a/app/organizer/view-event/[id]/page.tsx
+++ b/app/organizer/view-event/[id]/page.tsx
@@ -409,6 +409,7 @@ export default function EventDashboard() {
               eventName={event.name}
               eventDate={event.date}
               eventLocation={event.location}
+              ticketCategories={event.ticketCategories ?? []}
             />
           </motion.div>
         </motion.div>

--- a/app/verify-ticket/page.tsx
+++ b/app/verify-ticket/page.tsx
@@ -341,6 +341,23 @@ export default function VerifyTicketPage() {
                     </span>
                   </div>
                 )}
+                {inviteVerification.invite.ticketCategoryName && (
+                  <div className="flex justify-between gap-3">
+                    <span className="text-gray-600">Category</span>
+                    <span className="text-right font-semibold text-indigo-600 break-words">
+                      {inviteVerification.invite.ticketCategoryName}
+                    </span>
+                  </div>
+                )}
+                {!!inviteVerification.invite.admitsCount &&
+                  inviteVerification.invite.admitsCount > 1 && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Admits</span>
+                      <span className="text-gray-900 font-medium">
+                        {inviteVerification.invite.admitsCount}
+                      </span>
+                    </div>
+                  )}
                 <div className="flex justify-between">
                   <span className="text-gray-600">Event</span>
                   <span className="text-gray-900 font-medium">

--- a/components/invite-card.tsx
+++ b/components/invite-card.tsx
@@ -6,6 +6,7 @@ export interface InviteCardProps {
   eventLocation?: string | null;
   inviteeName?: string | null;
   admitsCount?: number | null;
+  categoryName?: string | null;
   qrUrl: string;
 }
 
@@ -25,7 +26,15 @@ const formatEventDate = (raw?: string | Date | null) => {
 
 export const InviteCard = forwardRef<HTMLDivElement, InviteCardProps>(
   function InviteCard(
-    { eventName, eventDate, eventLocation, inviteeName, admitsCount, qrUrl },
+    {
+      eventName,
+      eventDate,
+      eventLocation,
+      inviteeName,
+      admitsCount,
+      categoryName,
+      qrUrl,
+    },
     ref,
   ) {
     return (
@@ -77,12 +86,21 @@ export const InviteCard = forwardRef<HTMLDivElement, InviteCardProps>(
           >
             {inviteeName ? `Guest: ${inviteeName}` : "Personal invite"}
           </p>
-          <p
-            style={{ marginBottom: 4, lineHeight: 1.4 }}
-            className="text-xs text-slate-500"
-          >
-            Admits: {admitsCount && admitsCount > 1 ? admitsCount : 1}
-          </p>
+          {(() => {
+            const parts = [
+              categoryName || null,
+              admitsCount && admitsCount > 1 ? `admits ${admitsCount}` : null,
+            ].filter(Boolean);
+            if (!parts.length) return null;
+            return (
+              <p
+                style={{ marginBottom: 4, lineHeight: 1.4 }}
+                className="text-xs font-medium text-indigo-600 break-words"
+              >
+                {parts.join(" - ")}
+              </p>
+            );
+          })()}
           <p
             style={{ marginBottom: 20, lineHeight: 1.4 }}
             className="text-xs text-slate-500"

--- a/services/attendees/attendees.ts
+++ b/services/attendees/attendees.ts
@@ -22,7 +22,7 @@ export interface Attendee {
 export interface AttendeesResponse {
   eventId: string;
   total: number;
-  counts: { invites: number; tickets: number };
+  counts: { invites: number; tickets: number; holders: number };
   attendees: Attendee[];
 }
 

--- a/services/invites/invites.ts
+++ b/services/invites/invites.ts
@@ -10,6 +10,9 @@ export interface Invite {
   status: "PENDING" | "ACCEPTED" | "REVOKED";
   token: string;
   inviteLink?: string;
+  admitsCount?: number | null;
+  ticketCategoryId?: string | null;
+  ticketCategoryName?: string | null;
 }
 
 export type InviteDeliveryMode = "GENERATE" | "SEND";
@@ -20,6 +23,7 @@ export interface AddInviteePayload {
   name: string;
   mode?: InviteDeliveryMode;
   admitsCount?: number;
+  ticketCategoryId?: string;
 }
 
 export interface UpdateInvitePayload {
@@ -27,6 +31,7 @@ export interface UpdateInvitePayload {
   email?: string;
   phone?: string;
   tableNumber?: string;
+  ticketCategoryId?: string | null;
 }
 
 export interface ShareableLink {
@@ -35,10 +40,39 @@ export interface ShareableLink {
 
 const BASE = (eventId: string) => `events/${eventId}/invites`;
 
+interface RawInvite {
+  id: string;
+  email?: string | null;
+  phone?: string | null;
+  name?: string | null;
+  admitsCount?: number | null;
+  ticketCategoryId?: string | null;
+  ticketCategoryName?: string | null;
+  inviteLink?: string;
+  inviteToken?: string;
+  usedAt?: string | null;
+}
+
 export const listInvites = async (eventId: string): Promise<Invite[]> => {
   const endpoint = buildEndpoint("v2", BASE(eventId));
-  const res = await axios.get<Invite[]>(endpoint);
-  return res.data;
+  const res = await axios.get<{ invites?: RawInvite[] } | RawInvite[]>(endpoint);
+  // Backend returns { eventId, total, invites: [...] }; tolerate a bare array too.
+  const raw: RawInvite[] = Array.isArray(res.data)
+    ? res.data
+    : (res.data?.invites ?? []);
+  return raw.map((inv) => ({
+    id: inv.id,
+    eventId,
+    email: inv.email ?? null,
+    phone: inv.phone ?? null,
+    name: inv.name ?? "",
+    status: inv.usedAt ? "ACCEPTED" : "PENDING",
+    token: inv.inviteToken ?? "",
+    inviteLink: inv.inviteLink,
+    admitsCount: inv.admitsCount ?? null,
+    ticketCategoryId: inv.ticketCategoryId ?? null,
+    ticketCategoryName: inv.ticketCategoryName ?? null,
+  }));
 };
 
 export interface AddInvitesResponse {
@@ -51,6 +85,9 @@ export interface AddInvitesResponse {
     email: string | null;
     phone: string | null;
     name: string | null;
+    admitsCount?: number | null;
+    ticketCategoryId?: string | null;
+    ticketCategoryName?: string | null;
     inviteLink?: string;
     inviteToken?: string;
     createdAt?: string;
@@ -142,6 +179,8 @@ export interface VerifyInviteResponse {
     name: string | null;
     email: string | null;
     phone: string | null;
+    admitsCount?: number | null;
+    ticketCategoryName?: string | null;
   };
   event: {
     id: string;


### PR DESCRIPTION
- category Select in add-invite form and inline per-row edit
- InviteCard shows 'VIP - admits N' (admits hidden when 1)
- verify-ticket scan screen shows category + admits
- normalize listInvites response shape (unwrap invites[], derive status)
- attendees counts include combined holders total