### PR TITLE
fix: send role in register payload to resolve signup failure

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -13,7 +13,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { useRegister } from "@/services/auth/auth.queries";
-import { useBecomeOrganizer } from "@/services/user/user.queries";
 import { toast } from "sonner";
 import { Logo } from "@/components/layout/logo";
 
@@ -73,7 +72,6 @@ export default function RegisterPage() {
   });
 
   const { mutateAsync: registerUser, isPending } = useRegister();
-  const becomeOrganizerMutation = useBecomeOrganizer();
 
   const goToNextStep = async () => {
     const isStepOneValid = await trigger(["name", "email"]);
@@ -88,10 +86,10 @@ export default function RegisterPage() {
         name: data.name,
         email: data.email.toLowerCase(),
         password: data.password,
+        role: "ORGANIZER" as const,
       };
 
       await registerUser(payload);
-      await becomeOrganizerMutation.mutateAsync(data.email);
 
       localStorage.setItem(
         "otpPayload",


### PR DESCRIPTION
## Summary
- Frontend was omitting the `role` field from the registration payload
- Backend requires `role: ORGANIZER` at registration and threw "Only ORGANIZER or ADMIN can register directly" for every signup attempt
- Removed the now-redundant `becomeOrganizer` call that fired immediately after registration (user is already ORGANIZER at creation time)

## Test plan
- [ ] Go to /register and complete the signup form
- [ ] Confirm user is created successfully and redirected to OTP verification
- [ ] Verify OTP and confirm account is accessible as an organizer
- [ ] Confirm no "must be a user or organizer" error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)