### PR TITLE
feat: hide ticket sold counts from public event views

### DIFF
--- a/app/events/[slug]/_components/ticket-category-card.tsx
+++ b/app/events/[slug]/_components/ticket-category-card.tsx
@@ -23,7 +23,7 @@ export function TicketCategoryCardV2({
   feeMode,
   primaryFeeBps,
 }: Props) {
-  const available = category.maxTickets - category.minted;
+  const available = category.maxTickets - (category.minted ?? 0);
   const outOfStock = available <= 0;
   const fee =
     feeMode === "ATTENDEE"

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -51,7 +51,7 @@ export default function EventPage({ params }: { params: { slug: string } }) {
     const category = event?.ticketCategories.find((c) => c.id === id);
     if (!category) return;
 
-    const max = Math.min(category.maxTickets - category.minted, 10); // Max 10 per category
+    const max = Math.min(category.maxTickets - (category.minted ?? 0), 10); // Max 10 per category
     setQuantities((prev) => {
       const current = prev[id] ?? 1;
       const next = typeof value === "function" ? value(current) : value;
@@ -223,17 +223,7 @@ export default function EventPage({ params }: { params: { slug: string } }) {
                 </section>
 
                 <section className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-                  <StatCard
-                    label="Attendees"
-                    value={
-                      event.ticketCategories?.reduce(
-                        (a, b) => a + b.minted,
-                        0,
-                      ) ?? 0
-                    }
-                    icon={<Ticket className="h-5 w-5" />}
-                  />
-                  {/* Add more stats if you have data */}
+                  {/* Attendee count is not shown publicly */}
                 </section>
               </div>
 

--- a/app/explore/explore-event-card.tsx
+++ b/app/explore/explore-event-card.tsx
@@ -170,13 +170,12 @@ function ExploreEventCardComponent({
                     </span>
                     <span
                       className={
-                        ticket.maxTickets - ticket.minted < 5
+                        ticket.maxTickets - (ticket.minted ?? 0) < 5
                           ? "text-red-500 font-medium"
                           : "text-gray-600"
                       }
                     >
-                      {ticket.maxTickets - ticket.minted} of {ticket.maxTickets}{" "}
-                      available
+                      {ticket.maxTickets - (ticket.minted ?? 0)} available
                     </span>
                   </div>
                 ))}

--- a/app/explore/utils.ts
+++ b/app/explore/utils.ts
@@ -35,7 +35,7 @@ export function filterEvents(
 export function getTicketStats(event: EventV2) {
   const ticketCategories = event.ticketCategories || [];
   const maxTickets = ticketCategories.reduce((sum, t) => sum + t.maxTickets, 0);
-  const mintedTickets = ticketCategories.reduce((sum, t) => sum + t.minted, 0);
+  const mintedTickets = ticketCategories.reduce((sum, t) => sum + (t.minted ?? 0), 0);
   const ticketsAvailable = maxTickets - mintedTickets;
 
   return { ticketCategories, maxTickets, mintedTickets, ticketsAvailable };

--- a/components/event-card.tsx
+++ b/components/event-card.tsx
@@ -21,8 +21,7 @@ interface EventCardProps {
  * 2. CSS transition for smooth hover effect
  */
 export function EventCard({ event }: EventCardProps) {
-  const availableTickets = event.maxTickets - event.minted;
-  const soldOutPercentage = (event.minted / event.maxTickets) * 100;
+  const availableTickets = event.maxTickets - (event.minted ?? 0);
 
   return (
     <div className="event-card-hover">
@@ -71,19 +70,7 @@ export function EventCard({ event }: EventCardProps) {
               </div>
             </div>
 
-            {/* Progress bar for ticket sales */}
-            <div className="space-y-1">
-              <div className="flex justify-between text-xs text-muted-foreground">
-                <span>{event.minted} sold</span>
-                <span>{soldOutPercentage.toFixed(0)}% sold</span>
-              </div>
-              <div className="w-full bg-muted rounded-full h-2">
-                <div
-                  className="bg-primary h-2 rounded-full transition-all duration-300"
-                  style={{ width: `${soldOutPercentage}%` }}
-                />
-              </div>
-            </div>
+
 
             <div className="flex items-center justify-between pt-2">
               <div className="space-y-1">

--- a/components/structured-data.tsx
+++ b/components/structured-data.tsx
@@ -13,7 +13,7 @@ interface EventStructuredDataProps {
       price: number;
       name: string;
       maxTickets: number;
-      minted: number;
+      minted?: number;
     }>;
   };
 }
@@ -30,7 +30,7 @@ export function EventStructuredData({ event }: EventStructuredDataProps) {
   const totalTickets =
     event.ticketCategories?.reduce((sum, tc) => sum + tc.maxTickets, 0) || 0;
   const soldTickets =
-    event.ticketCategories?.reduce((sum, tc) => sum + tc.minted, 0) || 0;
+    event.ticketCategories?.reduce((sum, tc) => sum + (tc.minted ?? 0), 0) || 0;
   const availability = soldTickets >= totalTickets ? "SoldOut" : "InStock";
 
   const structuredData = {

--- a/components/ticket-purchase-modal/quantity-step.tsx
+++ b/components/ticket-purchase-modal/quantity-step.tsx
@@ -104,7 +104,7 @@ export function QuantityStep({
                 onClick={() => onQuantityChange(category.id, 1)}
                 disabled={
                   (quantities[category.id] || 0) >= 10 ||
-                  category.maxTickets - category.minted <=
+                  category.maxTickets - (category.minted ?? 0) <=
                     (quantities[category.id] || 0)
                 }
                 className="w-10 h-10 rounded-full border-gray-200 bg-transparent"
@@ -113,7 +113,7 @@ export function QuantityStep({
               </Button>
             </div>
             <p className="text-xs text-gray-500 text-center mt-2">
-              {category.maxTickets - category.minted} tickets available
+              {category.maxTickets - (category.minted ?? 0)} tickets available
             </p>
           </div>
         ))

--- a/types/events-v2.type.ts
+++ b/types/events-v2.type.ts
@@ -8,7 +8,7 @@ export interface TicketCategoryV2 {
   price: number;
   maxTickets: number;
   maxAdmissions: number;
-  minted: number;
+  minted?: number;
   eventId: string;
   displayPrice: number;
 }

--- a/types/events.type.ts
+++ b/types/events.type.ts
@@ -18,7 +18,7 @@ export interface TicketCategory {
   name: string;
   price: number;
   maxTickets: number;
-  minted: number;
+  minted?: number;
 }
 
 export interface Event {
@@ -36,7 +36,7 @@ export interface Event {
   updatedAt: string;
   slug: string;
   maxTickets: number;
-  minted: number;
+  minted?: number;
   organizerd: string;
   tickets: ResaleTicket[];
   ticketCategories?: TicketCategory[];

--- a/types/tickets.type.ts
+++ b/types/tickets.type.ts
@@ -6,7 +6,7 @@ export interface TicketCategory {
   id: string;
   name: string;
   price: number;
-  minted: number;
+  minted?: number;
   maxTickets: number;
 }
 


### PR DESCRIPTION
Remove displays of minted/sold ticket counts from public-facing pages (event cards, explore, event detail). Availability counts (X remaining) are kept for UX. Make minted optional in types since backend no longer returns it on public endpoints.