### PR TITLE
fix: remove remaining count from public ticket card

### DIFF
--- a/app/events/[slug]/_components/ticket-category-card.tsx
+++ b/app/events/[slug]/_components/ticket-category-card.tsx
@@ -44,7 +44,7 @@ export function TicketCategoryCardV2({
         <div>
           <h3 className="font-semibold text-lg">{category.name}</h3>
           <p className="text-sm text-muted-foreground mt-1">
-            {available} remaining • Admits {category.maxAdmissions}
+            Admits {category.maxAdmissions}
           </p>
         </div>
 


### PR DESCRIPTION
minted is not returned from public API endpoints (intentional), so available = maxTickets - 0 always showed full capacity. Just show "Admits N" which is accurate without needing minted.