### PR TITLE
fix(organizer): theme loading/error screens and rework event wizard l…

### DIFF
--- a/app/organizer/_components/event-wizard.tsx
+++ b/app/organizer/_components/event-wizard.tsx
@@ -11,7 +11,7 @@ import { useToggleEventStatus } from "@/services/events/events.queries";
 import { uploadImageToS3 } from "@/services/uploads/images";
 import { EventV2 } from "@/types/events-v2.type";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 
@@ -22,7 +22,7 @@ import {
   DEFAULT_FORM_VALUES,
 } from "./event-form-schema";
 import { isStep1Valid } from "./event-form-validation";
-import { ProgressBar } from "./progress-bar";
+import { StepRail } from "./step-rail";
 import { FormNavigation } from "./form-navigation";
 import { EventFormStepLayout } from "./event-form-step-layout";
 import { EventFormStep1 } from "./event-form-step1";
@@ -287,31 +287,37 @@ export function EventWizard({ mode, eventId, initialEvent }: EventWizardProps) {
         .organizer-event-form [class*="bg-[#1E88E5]"] { background-color: var(--home-accent) !important; color: var(--home-accent-fg) !important; }
         .organizer-event-form [class*="hover:border-[#1E88E5]"], .organizer-event-form [class*="hover:text-[#1E88E5]"] { --tw-border-opacity: 1; }
       `}</style>
-      <div className="container mx-auto px-4 py-8">
-        <div className="flex items-center justify-between mb-8">
-          <Button variant="outline" className="bg-transparent" asChild disabled={isSubmitting}>
+      <div className="max-w-[1200px] mx-auto px-4 md:px-10 py-8 md:pb-24 grid grid-cols-1 md:grid-cols-[260px_1fr] gap-8 md:gap-14">
+        <div className="flex flex-col gap-4 md:contents">
+          <Button variant="outline" className="bg-transparent w-fit md:order-last" asChild disabled={isSubmitting}>
             <Link href="/organizer">
               <HugeiconsIcon icon={ArrowLeft01Icon} className="h-4 w-4 mr-2" />
               Back to Dashboard
             </Link>
           </Button>
-          <div className="text-center">
-            <h1 className="text-3xl font-bold">{mode === "create" ? "Create Event" : "Update Event"}</h1>
-            <p className="text-[var(--home-muted)]">Step {currentStep} of {TOTAL_STEPS}</p>
+          <div className="md:order-first">
+            <StepRail
+              title={mode === "create" ? "Create Event" : "Update Event"}
+              currentStep={currentStep}
+              labels={STEP_LABELS}
+              onStepClick={setCurrentStep}
+            />
           </div>
-          <div className="w-32" />
         </div>
 
-        <ProgressBar currentStep={currentStep} totalSteps={TOTAL_STEPS} labels={STEP_LABELS} />
-
-        <Card className="max-w-2xl mx-auto bg-[var(--home-card)] text-[var(--home-text)] rounded-3xl shadow-none border border-[var(--home-border)]">
-          <CardHeader>
-            <CardTitle className="text-2xl">
+        <div className="flex flex-col gap-8 min-w-0">
+          <div className="flex flex-col gap-1.5">
+            <h1 className="text-2xl md:text-[26px] font-bold" style={{ color: "var(--home-text)" }}>
               {currentStep === 6 && layout ? `${layout.replace("_", " ")} Details` : STEP_LABELS[currentStep - 1]}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <form id="event-wizard-form">
+            </h1>
+            <p className="text-sm" style={{ color: "var(--home-muted)" }}>
+              Step {currentStep} of {TOTAL_STEPS}
+            </p>
+          </div>
+
+          <Card className="bg-[var(--home-card)] text-[var(--home-text)] rounded-3xl shadow-none border border-[var(--home-border)]">
+            <CardContent className="space-y-6 pt-6">
+              <form id="event-wizard-form">
               {currentStep === 1 && (
                 <EventFormStepLayout value={layout} onChange={(v) => setValue("layout", v)} />
               )}
@@ -375,8 +381,9 @@ export function EventWizard({ mode, eventId, initialEvent }: EventWizardProps) {
                 </div>
               )}
             </form>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/app/organizer/_components/form-navigation.tsx
+++ b/app/organizer/_components/form-navigation.tsx
@@ -52,7 +52,8 @@ export function FormNavigation({
       {currentStep < totalSteps ? (
         <Button
           type="button"
-          className="bg-[#1E88E5] hover:bg-blue-500 text-white rounded-full px-6 shadow-lg transition-[background-color,color,border-color,opacity,transform] duration-150"
+          className="rounded-full px-6 shadow-lg transition-[background-color,color,border-color,opacity,transform] duration-150 hover:opacity-90"
+          style={{ backgroundColor: "var(--home-accent)", color: "var(--home-accent-fg)" }}
           onClick={onNext}
           disabled={!canProceed || isSubmitting}
         >
@@ -63,7 +64,8 @@ export function FormNavigation({
         <Button
           type="submit"
           form={formId}
-          className="bg-[#1E88E5] hover:bg-blue-500 text-white rounded-full px-6 shadow-lg transition-[background-color,color,border-color,opacity,transform] duration-150"
+          className="rounded-full px-6 shadow-lg transition-[background-color,color,border-color,opacity,transform] duration-150 hover:opacity-90"
+          style={{ backgroundColor: "var(--home-accent)", color: "var(--home-accent-fg)" }}
           disabled={isSubmitting || !canSubmit}
         >
           {isSubmitting ? submittingLabel : submitLabel}

--- a/app/organizer/_components/status-screens.tsx
+++ b/app/organizer/_components/status-screens.tsx
@@ -16,11 +16,19 @@ export function LoadingScreen({
   subMessage = "Please wait",
 }: LoadingScreenProps) {
   return (
-    <div className="fixed inset-0 bg-gray-50 bg-opacity-90 flex items-center justify-center z-50 loading-screen-animate">
+    <div
+      className="home-theme fixed inset-0 flex items-center justify-center z-50 loading-screen-animate"
+      style={{ backgroundColor: "var(--home-bg)", opacity: 0.9 }}
+    >
       <div className="text-center">
-        <div className="w-16 h-16 border-4 border-[#1E88E5] border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-        <h2 className="text-xl font-semibold text-gray-900 mb-2">{message}</h2>
-        <p className="text-gray-600">{subMessage}</p>
+        <div
+          className="w-16 h-16 border-4 border-t-transparent rounded-full animate-spin mx-auto mb-4"
+          style={{ borderColor: "var(--home-accent)" }}
+        ></div>
+        <h2 className="text-xl font-semibold mb-2" style={{ color: "var(--home-text)" }}>
+          {message}
+        </h2>
+        <p style={{ color: "var(--home-muted)" }}>{subMessage}</p>
       </div>
     </div>
   );
@@ -43,12 +51,20 @@ export function ErrorScreen({
   backLabel = "Back to Dashboard",
 }: ErrorScreenProps) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-50 flex items-center justify-center px-4">
+    <div
+      className="home-theme min-h-screen flex items-center justify-center px-4"
+      style={{ backgroundColor: "var(--home-bg)" }}
+    >
       <div className="text-center max-w-md mx-auto p-8 error-screen-animate">
-        <h1 className="text-3xl font-bold mb-4">{title}</h1>
-        <p className="text-gray-600 mb-6">{message}</p>
+        <h1 className="text-3xl font-bold mb-4" style={{ color: "var(--home-text)" }}>
+          {title}
+        </h1>
+        <p className="mb-6" style={{ color: "var(--home-muted)" }}>
+          {message}
+        </p>
         <Button
-          className="bg-[#1E88E5] hover:bg-blue-500 text-white rounded-full px-6 shadow-lg transition-[background-color,color,border-color,opacity,transform] duration-150"
+          className="rounded-full px-6 shadow-lg transition-[background-color,color,border-color,opacity,transform] duration-150"
+          style={{ backgroundColor: "var(--home-accent)", color: "var(--home-accent-fg)" }}
           asChild
         >
           <Link href={backHref}>{backLabel}</Link>

--- a/app/organizer/_components/step-rail.tsx
+++ b/app/organizer/_components/step-rail.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+interface StepRailProps {
+  title: string;
+  currentStep: number;
+  labels: string[];
+  onStepClick: (step: number) => void;
+}
+
+/**
+ * Vertical sticky step navigator for the event wizard (left rail).
+ */
+export function StepRail({ title, currentStep, labels, onStepClick }: StepRailProps) {
+  return (
+    <div className="flex flex-col gap-1 sticky top-24 self-start">
+      <span className="mb-4 font-bold text-[22px]" style={{ color: "var(--home-text)" }}>
+        {title}
+      </span>
+      {labels.map((label, i) => {
+        const step = i + 1;
+        const active = step === currentStep;
+        const done = step < currentStep;
+        const clickable = step <= currentStep;
+        return (
+          <div
+            key={label}
+            className="flex items-center gap-3.5 py-3 px-2 rounded-lg transition-colors"
+            style={{ cursor: clickable ? "pointer" : "default", opacity: clickable ? 1 : 0.5 }}
+            onClick={() => clickable && onStepClick(step)}
+          >
+            <span
+              className="flex items-center justify-center rounded-full shrink-0 font-bold text-xs"
+              style={{
+                width: 26,
+                height: 26,
+                background: active || done ? "var(--home-accent)" : "var(--home-card-highlight)",
+                color: active || done ? "var(--home-accent-fg)" : "var(--home-muted)",
+              }}
+            >
+              {done ? "✓" : step}
+            </span>
+            <span
+              className="text-sm"
+              style={{
+                fontWeight: active ? 700 : 500,
+                color: active ? "var(--home-text)" : "var(--home-muted)",
+              }}
+            >
+              {label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
…ayout

Auth loading/error screens hardcoded light-theme Tailwind classes and a stray blue accent, causing a white flash against the dark organizer UI. Switch them to the app's --home-* CSS vars.

Replace the top progress-bar + centered card with a sticky left step-rail and wide content column, matching the approved event-creation mockup. The rail title now reflects create vs. update mode.